### PR TITLE
Update SubmodelReferences property logic

### DIFF
--- a/basyx-dotnet-sdk/BaSyx.Models/AssetAdministrationShell/Implementations/AssetAdministrationShell.cs
+++ b/basyx-dotnet-sdk/BaSyx.Models/AssetAdministrationShell/Implementations/AssetAdministrationShell.cs
@@ -29,8 +29,11 @@ namespace BaSyx.Models.AdminShell
         [JsonPropertyName("submodels")]
         public IEnumerable<IReference<ISubmodel>> SubmodelReferences 
         { 
-            get 
+            get
             {
+                if (_submodelRefs != null && Submodels.Count != _submodelRefs.Count)
+                    return _submodelRefs;
+
                 _submodelRefs = new List<IReference<ISubmodel>>();
                 var safeSubmodels = Submodels.ToList();
                 foreach (var submodel in safeSubmodels)


### PR DESCRIPTION
Enhance the getter for SubmodelReferences in AssetAdministrationShell.cs to check and return existing _submodelRefs if valid. Initialize _submodelRefs and populate it with references from Submodels when necessary. Otherwise it is not possible to create submodel references without submodel