### PR TITLE
fix: value handling for bool property

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Make sure Visual Studio is closed the first time you run these scripts. The firs
 - Change http method from delete to get for endpoint `/shells/{aasIdentifier}/$reference` (AssetAdministrationShellRepositoryController)
 - Fixed put '/submodels/{submodelIdentifier}' endpoint to replace submodel instead of update the submodel (SubmodelRepositoryController)
 - Fixed Submodel element serialization to write `valueType` property tp use XSD data type definition (SubmodelElementConverter)
+- The processing of values for Boolean properties has been corrected when these are provided as strings via the REST API. The return format for Boolean values via the REST API has been improved (upper- / lower-case).
 
 ## Features
 - Add Submodel Registry HTTP Server (SubmodelRegistryHttpServer)

--- a/basyx-dotnet-sdk/BaSyx.Models/AssetAdministrationShell/Common/ElementValue.cs
+++ b/basyx-dotnet-sdk/BaSyx.Models/AssetAdministrationShell/Common/ElementValue.cs
@@ -117,6 +117,8 @@ namespace BaSyx.Models.AdminShell
                 return dbl.ToString(IValue._nfi);
             else if (Value is float flt)
                 return flt.ToString(IValue._nfi);
+            else if (Value is bool boolean)
+                return boolean.ToString().ToLower();
             else
                 return Value?.ToString();
         }

--- a/basyx-dotnet-sdk/BaSyx.Models/Extensions/JsonConverters/ValueScopeConverter.cs
+++ b/basyx-dotnet-sdk/BaSyx.Models/Extensions/JsonConverters/ValueScopeConverter.cs
@@ -627,8 +627,12 @@ namespace BaSyx.Models.Extensions
 			}
 			else if (reader.TokenType == JsonTokenType.String)
 			{
-				string value = reader.GetString();
-				return new ElementValue(value, dataType ?? typeof(string));
+                string value = reader.GetString();
+
+                if (_dataType?.DataObjectType == DataObjectType.Bool && bool.TryParse(value, out bool result))
+                    return new ElementValue(value, dataType ?? typeof(bool));
+
+                return new ElementValue(value, dataType ?? typeof(string));
 			}
 			else if (reader.TokenType == JsonTokenType.True || reader.TokenType == JsonTokenType.False)
 			{


### PR DESCRIPTION
The processing of values for Boolean properties has been corrected when these are provided as strings via the REST API. The return format for Boolean values via the REST API has been improved (upper- / lower-case).