### PR TITLE
Handle null case for fileElement.Value.Value

### DIFF
--- a/basyx-dotnet-components/BaSyx.API.Http.Controllers/AssetAdministrationShell/SubmodelController.cs
+++ b/basyx-dotnet-components/BaSyx.API.Http.Controllers/AssetAdministrationShell/SubmodelController.cs
@@ -932,7 +932,13 @@ namespace BaSyx.API.Http.Controllers
             }
 
             IFileElement fileElement = fileElementRetrieved.Entity.Cast<IFileElement>();
-            string fileName = fileElement.Value.Value.TrimStart('/');
+
+            string fileName;
+            if (fileElement.Value.Value != null)
+                fileName = fileElement.Value.Value.TrimStart('/');
+            else
+                fileName = file.FileName;
+
             string filePath = Path.Combine(hostingEnvironment.ContentRootPath, fileName);
             
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));


### PR DESCRIPTION
Updated SubmodelController to check for null values in fileElement.Value.Value. If null, fileName is assigned from file.FileName, enhancing code robustness and preventing potential null reference exceptions.